### PR TITLE
Added "favorite" as an alias for high fan speed

### DIFF
--- a/capability.py
+++ b/capability.py
@@ -309,7 +309,7 @@ class FanSpeedCapability(_ModeCapability):
         'auto': ['auto'],
         'low': ['low', 'min', 'silent'],
         'medium': ['medium', 'middle'],
-        'high': ['high', 'max', 'strong'],
+        'high': ['high', 'max', 'strong', 'favorite'],
     }
 
     @staticmethod


### PR DESCRIPTION
Some "fan" domain devices, like the Xiaomi Air Purifier, have 3 modes: "auto", "silent" and "favorite". In this case, "favorite" mode should be mapped to "high fan speed" in Y smart home.