### PR TITLE
Расширенная поддержка пылесосов

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ track, get/set media_content_id via channel number for part of TVs(enabled
 via extra option "channel_set_via_media_content_id: true" in entity 
 configurations))
 - switch (on/off)
-- vacuum (on/off)
+- vacuum (on/off, pause/unpause, clean speed) (properties: battery)
 - water_heater (on/off, temperature)
 - lock (on/off = lock/unlock)
 - sensor (properties: temperature, humidity)

--- a/custom_components/yandex_smart_home/prop.py
+++ b/custom_components/yandex_smart_home/prop.py
@@ -6,6 +6,7 @@ from custom_components.yandex_smart_home.error import SmartHomeError
 from homeassistant.components import (
     climate,
     sensor,
+    vacuum,
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -137,6 +138,35 @@ class HumidityProperty(_Property):
             value = self.state.state
         elif self.state.domain == climate.DOMAIN:
             value = self.state.attributes.get(climate.ATTR_CURRENT_HUMIDITY)
+
+        if value in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
+            raise SmartHomeError(ERR_NOT_SUPPORTED_IN_CURRENT_MODE, "Invalid value")
+
+        return float(value)
+
+
+@register_property
+class BatteryProperty(_Property):
+    type = PROPERTY_FLOAT
+    instance = 'battery_level'
+
+    @staticmethod
+    def supported(domain, features, entity_config, attributes):
+        if domain == vacuum.DOMAIN:
+            return vacuum.ATTR_BATTERY_LEVEL in attributes
+
+        return False
+
+    def parameters(self):
+        return {
+            'instance': self.instance,
+            'unit': 'unit.percent'
+        }
+
+    def get_value(self):
+        value = 0
+        if self.state.domain == vacuum.DOMAIN:
+            value = self.state.attributes.get(vacuum.ATTR_BATTERY_LEVEL)
 
         if value in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
             raise SmartHomeError(ERR_NOT_SUPPORTED_IN_CURRENT_MODE, "Invalid value")


### PR DESCRIPTION
Добавил выбор режима уборки (возможно, стоит обсудить список режимов, или вообще сделать его конфигурируемым из yaml);
Добавил свойство Батарея (пока только для домена vacuum);
Добавил возможность ставить уборку на паузу.

Теперь пылесос из hass имеет тот же функционал, что и проброшенный через облако Mija.
Тестировал это всё на Roborock S50.