### PR TITLE
Fix climate current mode (always shows "heat")

### DIFF
--- a/custom_components/yandex_smart_home/capability.py
+++ b/custom_components/yandex_smart_home/capability.py
@@ -381,6 +381,11 @@ class ThermostatCapability(_ModeCapability):
 
         if operation is not None and operation in self.climate_map:
             return self.climate_map[operation]
+        
+        # Try to take current mode from device state
+        operation = self.state.state
+        if operation is not None and operation in self.climate_map:
+            return self.climate_map[operation]
 
         # Return first value if current one is not acceptable
         for operation in self.state.attributes.get(climate.ATTR_HVAC_MODES):


### PR DESCRIPTION
Fix when climate current mode is device state. That's why somebody always have the AC in Yandex shown in 'heat' mode, even if it's not.