### PR TITLE
Do not turn on scripts or scenes if they're actually asked to be turned off

### DIFF
--- a/custom_components/yandex_smart_home/capability.py
+++ b/custom_components/yandex_smart_home/capability.py
@@ -222,9 +222,8 @@ class OnOffCapability(_Capability):
                     service = vacuum.SERVICE_STOP
                 else:
                     service = SERVICE_TURN_OFF
-        elif self.state.domain == scene.DOMAIN or self.state.domain == \
-                script.DOMAIN:
-            service = SERVICE_TURN_ON
+        elif self.state.domain == scene.DOMAIN or self.state.domain == script.DOMAIN:
+            service = SERVICE_TURN_ON if state['value'] else SERVICE_TURN_OFF
         elif self.state.domain == lock.DOMAIN:
             service = SERVICE_UNLOCK if state['value'] else \
                 SERVICE_LOCK


### PR DESCRIPTION
Попросил Алису "выключить **всё** в прихожей", все устройства выключились, но туда поехал робот-пылесос, т.к. в прихожей была сущность script.vacuum_hallway.

Фикс, чтобы такого больше не случалось :)