### PR TITLE
Add custom mode mapping support for humidifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ yandex_smart_home:
         max: 95
         min: 20
         precision: 2
+    humidifier.bedroom:
+      modes:
+        program:
+          normal:
+            - normal
+          eco:
+            - away
+      properties:
+        - type: temperature
+          entity: sensor.bedroom_temperature
+        - type: humidity
+          entity: sensor.bedroom_humidity
+        - type: water_level
+          entity: sensor.humidifier_level
 ```
 
 Configuration variables:
@@ -116,9 +130,10 @@ yandex_smart_home:
           (float) (Optional) Range Precision (adjustment step)
       modes:
         (map) (Optional) Map of yandex mode functions (https://yandex.ru/dev/dialogs/alice/doc/smart-home/concepts/mode-instance-docpage/)
-        fan_speed|cleanup_mode:
+        fan_speed|cleanup_mode|program:
           (map) (Optional) Map of yandex modes (https://yandex.ru/dev/dialogs/alice/doc/smart-home/concepts/mode-instance-modes-docpage/) to HA modes.
-          yandex_mode1: ha_mode1
+          yandex_mode1:
+            - ha_mode1
           yandex_mode2: [ha_mode2, ha_mode2b]
 ```
 

--- a/custom_components/yandex_smart_home/capability.py
+++ b/custom_components/yandex_smart_home/capability.py
@@ -496,30 +496,30 @@ class ProgramCapability(_ModeCapability):
 
     # Because there is no 1 to 1 compatibility between default humidifier modes and yandex modes,
     # we just chose what is closest or at least not too confusing
-    humidifier_mode_map = {
-        humidifier.const.MODE_NORMAL: "normal",
-        humidifier.const.MODE_ECO: "eco",
-        humidifier.const.MODE_AWAY: "min",
-        humidifier.const.MODE_BOOST: "turbo",
-        humidifier.const.MODE_COMFORT: "medium",
-        humidifier.const.MODE_HOME: "max",
-        humidifier.const.MODE_SLEEP: "quiet",
-        humidifier.const.MODE_AUTO: "auto",
-        humidifier.const.MODE_BABY: "high",
+    modes_map = {
+        'normal': [humidifier.const.MODE_NORMAL],
+        'eco': [humidifier.const.MODE_ECO],
+        'min': [humidifier.const.MODE_AWAY],
+        'turbo': [humidifier.const.MODE_BOOST],
+        'medium': [humidifier.const.MODE_COMFORT],
+        'max': [humidifier.const.MODE_HOME],
+        'quiet': [humidifier.const.MODE_SLEEP],
+        'auto': [humidifier.const.MODE_AUTO],
+        'high': [humidifier.const.MODE_BABY],
     }
 
     # For custom modes we fallback to its number
     fallback_program_map = {
-        1: "one",
-        2: "two",
-        3: "three",
-        4: "four",
-        5: "five",
-        6: "six",
-        7: "seven",
-        8: "eight",
-        9: "nine",
-        10: "ten",
+        0: "one",
+        1: "two",
+        2: "three",
+        3: "four",
+        4: "five",
+        5: "six",
+        6: "seven",
+        7: "eight",
+        8: "nine",
+        9: "ten",
     }
 
     @staticmethod
@@ -536,13 +536,10 @@ class ProgramCapability(_ModeCapability):
             modes = []
             for mode in mode_list:
                 value = self.get_yandex_mode_by_ha_mode(mode)
-                # First, try to get yandex mode from configuration, if provided
                 if value is not None:
                     modes.append({"value": value})
-                # Next, try the map of default modes
-                elif mode in self.humidifier_mode_map:
-                    modes.append({"value": self.humidifier_mode_map[mode]})
-                # Lastly, enumerate the mode by its position in the mode list
+                # If mapping not found in configuration or default map,
+                # enumerate the mode by its position in the mode list
                 else:
                     mode_index = mode_list.index(mode)
                     if mode_index <= 10:
@@ -560,9 +557,6 @@ class ProgramCapability(_ModeCapability):
                 ya_mode = self.get_yandex_mode_by_ha_mode(mode)
                 if ya_mode is not None:
                     return ya_mode
-
-                if mode in self.humidifier_mode_map:
-                    return self.humidifier_mode_map[mode]
 
                 # Fallback into numeric mode
                 mode_list = self.state.attributes.get(humidifier.ATTR_AVAILABLE_MODES)
@@ -582,12 +576,10 @@ class ProgramCapability(_ModeCapability):
             attr = humidifier.ATTR_MODE
 
             mode_list = self.state.attributes.get(humidifier.ATTR_AVAILABLE_MODES)
-            value = self.get_ha_mode_by_yandex_mode(state["value"], mode_list)
-            if value is None:
-                for humidifier_value, yandex_value in self.humidifier_mode_map.items():
-                    if yandex_value == state["value"]:
-                        value = humidifier_value
-                        break
+            try:
+                value = self.get_ha_mode_by_yandex_mode(state["value"], mode_list)
+            except KeyError:
+                pass
 
             if value is None:
                 for humidifier_value, yandex_value in self.fallback_program_map.items():


### PR DESCRIPTION
Не успел дотестить вовремя, чтобы включить всё в #104 :)

Добавляю пример конфига в README и поддержку пользотельского маппинга режимов работы.
Надеюсь, я правильно понял, как это делается в #98.

В интеграции `humidifier` можно использовать произвольный набор режимов. При этом есть несколько встроеных (самых частых) режимов, которые будут переводиться на другие языки, но требования ограничиваться этим списком нет. Этим `humidifier`, например, отличается от `climate`.
У Яндекса есть свой список, при этом расширять его нельзя, и маппировать 1:1 эти списки не получается.

Теперь маппирование будет происходить так:
1. Для каждого режима, если есть пользовательский маппинг в configuration.yaml - будет использоваться он
2. Затем будет использоваться встроенный маппинг для стандартных режимов
3. Все остальные режимы будут нумероваться просто по номерам (типа, "Алиса, включи третий режим увлажнителя в спальне"). Это работает только до 10 режима, дальше - извините, перебор, нужен пользовательский маппинг

Можно придумать и более "умный" вариант, но для этой задачи переусложнять уже не хочется.

Надеюсь, комментариев в коде достаточно.

![tempFileForShare_20201030-183013](https://user-images.githubusercontent.com/2741408/97725216-f925d480-1ade-11eb-9c9e-5f10fc2e6edb.jpg)
