### PR TITLE
Дополнительные фиксы для давления

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ yandex_smart_home:
         (boolean) (Optional) (media_player only) Force disable ability to get/set volume by number
       properties:
         - type:
-            (string) (Optional) Sensor type, available types: humidity, temperature, water_level, co2_level, power, voltage, battery_level, amperage
+            (string) (Optional) Sensor type, available types: humidity, temperature, pressure, water_level, co2_level, power, voltage, battery_level, amperage
           entity:
             (string) (Optional) Custom entity, any sensor can be added 
           attribute:
@@ -157,7 +157,7 @@ configurations))
 - vacuum (on/off, pause/unpause, clean speed) (properties: battery)
 - water_heater (on/off, temperature)
 - lock (on/off = lock/unlock)
-- sensor (properties: temperature, humidity)
+- sensor (properties: temperature, humidity, pressure)
 - humidifier (on/off, mode, target humidity)
 
 ### Room/Area support

--- a/custom_components/yandex_smart_home/prop.py
+++ b/custom_components/yandex_smart_home/prop.py
@@ -210,7 +210,7 @@ class PressureProperty(_Property):
                 ERR_NOT_SUPPORTED_IN_CURRENT_MODE,
                 "Invalid value")
 
-        return float(value)
+        return float(value) * 100
 
 @register_property
 class BatteryProperty(_Property):
@@ -272,6 +272,7 @@ class CustomEntityProperty(_Property):
     instance_unit = {
         'humidity': 'unit.percent',
         'temperature': 'unit.temperature.celsius',
+        'pressure': 'unit.pressure.pascal',
         'water_level': 'unit.percent',
         'co2_level': 'unit.ppm',
         'power': 'unit.watt',


### PR DESCRIPTION
- Поддержка custom entity для давления
- Фикс величин - Яндекс ожидает в паскалях, HA отдает в гектапаскалях, поэтому умножаем на 100.
  TODO можно попробовать поддержать другие величины - HA умеет еще мБар, Яндекс еще больше (атм, мбар, паскаль, мм рт ст). Но тут нужно подумать как грамотно конвертировать.
- Обновил ридми