### PR TITLE
add version

### DIFF
--- a/custom_components/yandex_smart_home/manifest.json
+++ b/custom_components/yandex_smart_home/manifest.json
@@ -6,5 +6,6 @@
   "dependencies": [
     "http"
   ],
-  "codeowners": []
+  "codeowners": [],
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Fix https://github.com/dmitry-k/yandex_smart_home/issues/153 I have not seen warnings about version in the logs yet, but I know that it is required in new HA. I use HACS, but there are users who add the component manually, where the version number is definitely needed.