### PR TITLE
Don't overwrite shared storage + Update ContactProperty

### DIFF
--- a/custom_components/yandex_smart_home/http.py
+++ b/custom_components/yandex_smart_home/http.py
@@ -21,18 +21,14 @@ _LOGGER = logging.getLogger(__name__)
 @callback
 def async_register_http(hass, cfg):
     """Register HTTP views for Yandex Smart Home."""
-    config = Config(
+    hass.data[DOMAIN][DATA_CONFIG] = Config(
         settings=cfg.get(CONF_SETTINGS),
         should_expose=cfg.get(CONF_FILTER),
         entity_config=cfg.get(CONF_ENTITY_CONFIG)
     )
 
-    hass.data[DOMAIN] = {
-        DATA_CONFIG: config
-    }
-
     hass.http.register_view(YandexSmartHomeUnauthorizedView())
-    hass.http.register_view(YandexSmartHomeView(config))
+    hass.http.register_view(YandexSmartHomeView(hass.data[DOMAIN][DATA_CONFIG]))
 
 
 class YandexSmartHomeUnauthorizedView(HomeAssistantView):

--- a/custom_components/yandex_smart_home/prop.py
+++ b/custom_components/yandex_smart_home/prop.py
@@ -268,7 +268,7 @@ class ContactProperty(_BoolProperty):
     @staticmethod
     def supported(domain, features, entity_config, attributes):
         if domain == binary_sensor.DOMAIN:
-            return attributes.get(ATTR_DEVICE_CLASS) == 'opening'
+            return attributes.get(ATTR_DEVICE_CLASS) in ['door', 'garage_door', 'window', 'opening']
 
         return False
 

--- a/custom_components/yandex_smart_home/prop.py
+++ b/custom_components/yandex_smart_home/prop.py
@@ -20,6 +20,11 @@ from homeassistant.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_PRESSURE,
+    DEVICE_CLASS_DOOR,
+    DEVICE_CLASS_GARAGE_DOOR,
+    DEVICE_CLASS_OPENING,
+    DEVICE_CLASS_WINDOW,
+    DEVICE_CLASS_MOTION,
     STATE_UNAVAILABLE,
     STATE_ON,
     STATE_OFF,
@@ -268,7 +273,7 @@ class ContactProperty(_BoolProperty):
     @staticmethod
     def supported(domain, features, entity_config, attributes):
         if domain == binary_sensor.DOMAIN:
-            return attributes.get(ATTR_DEVICE_CLASS) in ['door', 'garage_door', 'window', 'opening']
+            return attributes.get(ATTR_DEVICE_CLASS) in [DEVICE_CLASS_DOOR, DEVICE_CLASS_GARAGE_DOOR, DEVICE_CLASS_OPENING, DEVICE_CLASS_WINDOW]
 
         return False
 
@@ -279,7 +284,7 @@ class MotionProperty(_BoolProperty):
     @staticmethod
     def supported(domain, features, entity_config, attributes):
         if domain == binary_sensor.DOMAIN:
-            return attributes.get(ATTR_DEVICE_CLASS) == 'motion'
+            return attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_MOTION
 
         return False
 


### PR DESCRIPTION
hass.data[DOMAIN] is shared data. Overwriting it here another modules of this component will not be able to use it. You should only access the elements you are working with, and not overwrite hass.data [DOMAIN] completely.

Contact sensor device_class not only `opening`, so added `door`, `garage_door`, `window`