### PR TITLE
Автоматическое обновление списка устройств при запуске Home Assistant

### DIFF
--- a/custom_components/yandex_smart_home/notifier.py
+++ b/custom_components/yandex_smart_home/notifier.py
@@ -35,10 +35,15 @@ def setup_notification(hass: HomeAssistant):
 
         hass.data[DOMAIN][NOTIFIER_ENABLED] = True
 
-        async def listener(event: Event):
+        async def state_change_listener(event: Event):
             await notifier.async_event_handler(event)
+            
+        async def ha_start_listener(event: Event):
+            await notifier.async_notify_skill([])
+            _LOGGER.debug('Device list update initiated')
 
-        hass.bus.async_listen('state_changed', listener)
+        hass.bus.async_listen('state_changed', state_change_listener)
+        hass.bus.async_listen('homeassistant_start', ha_start_listener)
 
     except Exception:
         _LOGGER.exception("Notifier Setup Error")

--- a/custom_components/yandex_smart_home/notifier.py
+++ b/custom_components/yandex_smart_home/notifier.py
@@ -99,10 +99,10 @@ class YandexNotifier:
             data = await r.json()
             error = data.get('error_message')
             if error:
-                _LOGGER.error(f"Notification sending error: {error}")
+                _LOGGER.error(f"Error sending notification: {error}")
                 return
         except Exception:
-            _LOGGER.error("Notification sending error")
+            _LOGGER.error("Error sending notification")
 
     async def async_event_handler(self, event: Event):
         devices = []

--- a/custom_components/yandex_smart_home/notifier.py
+++ b/custom_components/yandex_smart_home/notifier.py
@@ -1,5 +1,6 @@
 import logging
-from time import time, sleep
+from asyncio import sleep
+from time import time
 from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, Event
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
@@ -39,12 +40,12 @@ def setup_notification(hass: HomeAssistant):
             await notifier.async_event_handler(event)
             
         async def ha_start_listener(event: Event):
-            sleep(1)
+            await sleep(10)
             await notifier.async_notify_skill([])
             _LOGGER.debug('Device list update initiated')
 
         hass.bus.async_listen('state_changed', state_change_listener)
-        hass.bus.async_listen('homeassistant_start', ha_start_listener)
+        hass.bus.async_listen('homeassistant_started', ha_start_listener)
 
     except Exception:
         _LOGGER.exception("Notifier Setup Error")

--- a/custom_components/yandex_smart_home/notifier.py
+++ b/custom_components/yandex_smart_home/notifier.py
@@ -1,5 +1,5 @@
 import logging
-from time import time
+from time import time, sleep
 from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, Event
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
@@ -39,6 +39,7 @@ def setup_notification(hass: HomeAssistant):
             await notifier.async_event_handler(event)
             
         async def ha_start_listener(event: Event):
+            sleep(1)
             await notifier.async_notify_skill([])
             _LOGGER.debug('Device list update initiated')
 


### PR DESCRIPTION
После этого изменения ХА будет при запуске сам "пинать" УДЯ и он будет присылать запрос на обновление списка устройств. После чего, если есть новые (не удаленные, а абсолютно новые с точки зрения УДЯ) устройства приложение Яндекс должно прислать пуш о найденных устройствах. А сами устройства появятся в списке. Если удалить устройство из УДЯ и пытаться таким образом обновить список - ничего не произойдет - "старые" устройства придется как и раньше добавлять вручную, обновляя список через УДЯ.
![image](https://user-images.githubusercontent.com/8779304/118821546-05794f80-b8c0-11eb-8f71-7119f33996e7.png)

https://yandex.ru/dev/dialogs/smart-home/doc/reference-alerts/post-skill_id-callback-discovery.html