### PR TITLE
Fix #209

### DIFF
--- a/custom_components/yandex_smart_home/capability.py
+++ b/custom_components/yandex_smart_home/capability.py
@@ -95,13 +95,14 @@ class _Capability:
 
     def get_state(self):
         """Return the state of this capability for this entity."""
+        value = self.get_value()
         return {
             'type': self.type,
             'state':  {
                 'instance': self.instance,
-                'value': self.get_value()
+                'value': value
             }
-        }
+        } if value is not None else None
 
     def parameters(self):
         """Return parameters for a devices request."""

--- a/custom_components/yandex_smart_home/helpers.py
+++ b/custom_components/yandex_smart_home/helpers.py
@@ -213,8 +213,9 @@ class YandexEntity:
 
         capabilities = []
         for cpb in self.capabilities():
-            if cpb.retrievable:
-                capabilities.append(cpb.get_state())
+            cpb_state = cpb.get_state()
+            if cpb.retrievable and cpb_state is not None:
+                capabilities.append(cpb_state)
 
         properties = []
         for ppt in self.properties():


### PR DESCRIPTION
Это изменение предотвращает отправку значения `null` Яндексу, если значение не задано.

Fix #209