### PR TITLE
Don't lose exception details on "Error sending notification"

### DIFF
--- a/custom_components/yandex_smart_home/notifier.py
+++ b/custom_components/yandex_smart_home/notifier.py
@@ -103,7 +103,7 @@ class YandexNotifier:
                 _LOGGER.error(f"Error sending notification: {error}")
                 return
         except Exception:
-            _LOGGER.error("Error sending notification")
+            _LOGGER.exception("Error sending notification")
 
     async def async_event_handler(self, event: Event):
         devices = []


### PR DESCRIPTION
This is the only place left where exception is silently ignored and we log useless `Error sending notification`. Switched to `.exception` to log Exception too.

Helps to debug: https://github.com/dmitry-k/yandex_smart_home/issues/203