### PR TITLE
Fix KeyError 'max_mireds'

### DIFF
--- a/custom_components/yandex_smart_home/capability.py
+++ b/custom_components/yandex_smart_home/capability.py
@@ -1333,16 +1333,21 @@ class TemperatureKCapability(_ColorSettingCapability):
     def supported(domain, features, entity_config, attributes):
         """Test if state is supported."""
         return domain == light.DOMAIN and (
-            features & light.SUPPORT_COLOR or light.color_temp_supported(attributes.get(light.ATTR_SUPPORTED_COLOR_MODES))
+            features & light.SUPPORT_COLOR_TEMP or light.color_temp_supported(attributes.get(light.ATTR_SUPPORTED_COLOR_MODES))
         )
 
     def get_value(self):
         """Return the state value of this capability for this entity."""
-        kelvin = self.state.attributes.get(light.ATTR_COLOR_TEMP)
-        if kelvin is None:
-            kelvin = self.state.attributes[light.ATTR_MAX_MIREDS]
 
-        return color_util.color_temperature_mired_to_kelvin(kelvin)
+        return color_util.color_temperature_mired_to_kelvin(
+            self.state.attributes.get(
+                light.ATTR_COLOR_TEMP, 
+                self.state.attributes.get(
+                    light.ATTR_MAX_MIREDS, 
+                    500
+                )
+            )
+        )
 
     async def set_state(self, data, state):
         """Set device state."""


### PR DESCRIPTION
В #214 была [замена](https://github.com/dmitry-k/yandex_smart_home/commit/e40db3fae97750d9e9ed07afca20145a3977e3f2#:~:text=and%20features%20%26%20light.-,SUPPORT_COLOR_TEMP,-return%20domain%20%3D%3D%20light) `SUPPORT_COLOR_TEMP` на `SUPPORT_COLOR`- я думаю это опечатка. 
Жаловались [тут](https://github.com/dmitry-k/yandex_smart_home/issues/226#issuecomment-871638069) и в чате ([1](https://t.me/yandex_smart_home/16), [2](https://t.me/yandex_smart_home/191)).
Также добавлялось умение temperature_k светильникам которые не умели в цветовую температуру.