### PR TITLE
Fix DEVICE_UNREACHABLE state

### DIFF
--- a/custom_components/yandex_smart_home/helpers.py
+++ b/custom_components/yandex_smart_home/helpers.py
@@ -210,7 +210,7 @@ class YandexEntity:
         state = self.state
 
         if state is None or state.state == STATE_UNAVAILABLE:
-            return {'error_code': ERR_DEVICE_UNREACHABLE}
+            return {'id': state.entity_id, 'error_code': ERR_DEVICE_UNREACHABLE}
 
         capabilities = []
         for cpb in self.capabilities():
@@ -235,7 +235,7 @@ class YandexEntity:
         state = self.state
 
         if state is None or state.state == STATE_UNAVAILABLE:
-            return {'error_code': ERR_DEVICE_UNREACHABLE}
+            return {'id': state.entity_id, 'error_code': ERR_DEVICE_UNREACHABLE}
 
         capabilities = []
         for cpb in self.capabilities():


### PR DESCRIPTION
Согласно [документации](https://yandex.ru/dev/dialogs/smart-home/doc/reference/post-devices-query.html#output-structure) `id` нужно обязательно указывать. Иначе, если провалиться в устройство - оно выглядит как доступное - УДЯ игнорирует его недоступность вследствие неправильного запроса.