### PR TITLE
Уведомление нескольких навыков/пользователей

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,14 @@ yandex_smart_home:
     skill_id: xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx
     user_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
 ```
+If you need to notify multiple skills, you can enter their details in a list.
+```
+yandex_smart_home:
+  notifier:
+    - oauth_token: XXXXXXXXXXXXXXXXXXXXXXXXXXX
+      skill_id: xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx
+      user_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+    - oauth_token: YYYYYYYYYYYYYYYYYYYYYYYYYYY
+      skill_id: yyyyyyyy-yyyy-yyyy-yyyyyyyyyyyy
+      user_id: yyyyyyyyyyyyyyyyyyyyyyyyyyyy
+```

--- a/custom_components/yandex_smart_home/__init__.py
+++ b/custom_components/yandex_smart_home/__init__.py
@@ -46,9 +46,9 @@ ENTITY_SCHEMA = vol.Schema({
 })
 
 NOTIFIER_SCHEMA = vol.Schema({
-    vol.Optional(CONF_SKILL_OAUTH_TOKEN): cv.string,
-    vol.Optional(CONF_SKILL_ID): cv.string,
-    vol.Optional(CONF_NOTIFIER_USER_ID): cv.string,
+    vol.Required(CONF_SKILL_OAUTH_TOKEN): cv.string,
+    vol.Required(CONF_SKILL_ID): cv.string,
+    vol.Required(CONF_NOTIFIER_USER_ID): cv.string,
 }, extra=vol.PREVENT_EXTRA)
 
 def pressure_unit_validate(unit):

--- a/custom_components/yandex_smart_home/__init__.py
+++ b/custom_components/yandex_smart_home/__init__.py
@@ -65,7 +65,7 @@ SETTINGS_SCHEMA = vol.Schema({
 
 YANDEX_SMART_HOME_SCHEMA = vol.All(
     vol.Schema({
-        vol.Optional(CONF_NOTIFIER, default={}): NOTIFIER_SCHEMA,
+        vol.Optional(CONF_NOTIFIER, default={}): vol.All(cv.ensure_list, [NOTIFIER_SCHEMA]),
         vol.Optional(CONF_SETTINGS, default={}): SETTINGS_SCHEMA,
         vol.Optional(CONF_FILTER, default={}): entityfilter.FILTER_SCHEMA,
         vol.Optional(CONF_ENTITY_CONFIG, default={}): {cv.entity_id: ENTITY_SCHEMA},

--- a/custom_components/yandex_smart_home/const.py
+++ b/custom_components/yandex_smart_home/const.py
@@ -47,7 +47,8 @@ CONF_NOTIFIER = 'notifier'
 CONF_SKILL_OAUTH_TOKEN = 'oauth_token'
 CONF_SKILL_ID = 'skill_id'
 CONF_NOTIFIER_USER_ID = 'user_id'  
-NOTIFIER_ENABLED = 'notifier_enabled'    
+NOTIFIER_ENABLED = 'notifier_enabled'   
+NOTIFIERS = 'notifiers' 
 
 # https://yandex.ru/dev/dialogs/alice/doc/smart-home/concepts/device-types.html/
 PREFIX_TYPES = 'devices.types.'

--- a/custom_components/yandex_smart_home/notifier.py
+++ b/custom_components/yandex_smart_home/notifier.py
@@ -160,3 +160,4 @@ class YandexNotifier:
         if devices:
             await asyncio.sleep(.1)
             await self.async_notify_skill(devices)
+

--- a/custom_components/yandex_smart_home/notifier.py
+++ b/custom_components/yandex_smart_home/notifier.py
@@ -140,7 +140,6 @@ class YandexNotifier:
         for entity in entity_list:
             if entity in CLOUD_NEVER_EXPOSED_ENTITIES or \
                 not self.hass.data[DOMAIN][DATA_CONFIG].should_expose(entity): 
-                # and entity not in self.hass.data[DOMAIN][DATA_CONFIG].entity_config.keys()
                 continue
             state = new_state if entity == event_entity_id else self.hass.states.get(entity)
             yandex_entity = YandexEntity(self.hass, self.hass.data[DOMAIN][DATA_CONFIG], state)

--- a/custom_components/yandex_smart_home/notifier.py
+++ b/custom_components/yandex_smart_home/notifier.py
@@ -38,7 +38,7 @@ def setup_notification(hass: HomeAssistant):
                     title="Yandex Smart Home")
                 return False
 
-        hass.data[DOMAIN][NOTIFIER_ENABLED] = True
+            hass.data[DOMAIN][NOTIFIER_ENABLED] = True
 
         async def state_change_listener(event: Event):
             await asyncio.gather(*[n.async_event_handler(event) for n in hass.data[DOMAIN][NOTIFIERS]])

--- a/custom_components/yandex_smart_home/notifier.py
+++ b/custom_components/yandex_smart_home/notifier.py
@@ -47,8 +47,7 @@ def setup_notification(hass: HomeAssistant):
             await asyncio.sleep(10)
             for notifier in hass.data[DOMAIN][NOTIFIERS]:
                 await notifier.async_notify_skill([])
-                _LOGGER.debug(("[" + notifier.skill_id + "] " if \
-                len(hass.data[DOMAIN][NOTIFIERS]) > 1 else "") + "Device list update initiated")
+                _LOGGER.debug(notifier.log_id() + "Device list update initiated")
 
         hass.bus.async_listen('state_changed', state_change_listener)
         hass.bus.async_listen('homeassistant_started', ha_start_listener)
@@ -83,7 +82,10 @@ class YandexNotifier:
         except Exception:
             _LOGGER.exception("Notifier Init Failed")
         return True
-        
+
+    def log_id(self):
+        return "[ " + self.skill_id + " | " + self.user_id + " ] " if len(self.hass.data[DOMAIN][NOTIFIERS]) > 1 else ""
+
     def get_property_entities(self):
         cfg = self.hass.data[DOMAIN][DATA_CONFIG].entity_config
         for entity in cfg:
@@ -114,12 +116,10 @@ class YandexNotifier:
             data = await r.json()
             error = data.get('error_message')
             if error:
-                _LOGGER.error(("[" + self.skill_id + "] " if \
-                len(self.hass.data[DOMAIN][NOTIFIERS]) > 1 else "") + "Error sending notification: " + error)
+                _LOGGER.error(self.log_id() + "Error sending notification: " + error)
                 return
         except Exception:
-            _LOGGER.exception(("[" + self.skill_id + "] " if \
-            len(self.hass.data[DOMAIN][NOTIFIERS]) > 1 else "") + "Error sending notification")
+            _LOGGER.exception(self.log_id() + "Error sending notification")
 
     async def async_event_handler(self, event: Event):
         devices = []
@@ -154,9 +154,7 @@ class YandexNotifier:
                 entity_text = entity
                 if entity != event_entity_id:
                     entity_text = entity_text + " => " + event_entity_id
-                _LOGGER.debug(("[" + self.skill_id + "] " if \
-                len(self.hass.data[DOMAIN][NOTIFIERS]) > 1 else "") + \
-                "Notify Yandex about new state " + \
+                _LOGGER.debug(self.log_id() + "Notify Yandex about new state " + \
                 entity_text + ": " + new_state.state)
         
         if devices:


### PR DESCRIPTION
В УДЯ есть [возможность](https://yandex.ru/dev/dialogs/alice/doc/access.html) делиться навыком УД с другими пользователями. Также можно создать 2 и более одинаковых навыков у разных пользователей Яндекса (но это не всегда корректно работает).
Для отправки данных 2 и более навыкам нужно токен для каждого из них, ID навыка, а также ID пользователей ХА которым соответствуют пользователи Яндекса. То есть те же данные, только для каждого из навыков/пользователей.
Эти данные нужно заполнить списком:
```
yandex_smart_home:
  notifier:
    - oauth_token: XXXXXXXXXXXXXXXXXXXXXXXXXXX
      skill_id: xxxxxxxx-xxxx-xxxx-xxxxxxxxxxxx
      user_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
    - oauth_token: YYYYYYYYYYYYYYYYYYYYYYYYYYY
      skill_id: yyyyyyyy-yyyy-yyyy-yyyyyyyyyyyy
      user_id: yyyyyyyyyyyyyyyyyyyyyyyyyyyy
```
Настройка в текущем виде также поддерживается - конфигурацию можно не менять если навык УД только один.
Спасибо @dext0r за идею и консультации =)