### PR TITLE
Не отключать светильники при установке минимальной яркости

### DIFF
--- a/custom_components/yandex_smart_home/capability.py
+++ b/custom_components/yandex_smart_home/capability.py
@@ -1051,7 +1051,7 @@ class BrightnessCapability(_RangeCapability):
             'instance': self.instance,
             'unit': 'unit.percent',
             'range': {
-                'min': 0,
+                'min': 1,
                 'max': 100,
                 'precision': 1
             }


### PR DESCRIPTION
Сейчас для BrightnessCapability минимальное значение 0. Однако, HA интерпретирует яркость 0 как необходимость полностью отключить светильник (т.е. вызывается light.turn_off). Поэтому при команде "Алиса, минимальная яркость света" лампочка выключится полностью (см. #244).
Кроме того, через интерфейс HA невозможно задать яркость < 1%. И в [примерах](https://yandex.ru/dev/dialogs/smart-home/doc/concepts/device-type-light.html#device-type-light__exmples) из документации Яндекса min тоже 1.

Зависит от #248.
Fixes #244.