### PR TITLE
Не возвращать "нулевые" значения для яркости, цвета и температуры

### DIFF
--- a/custom_components/yandex_smart_home/capability.py
+++ b/custom_components/yandex_smart_home/capability.py
@@ -1060,9 +1060,7 @@ class BrightnessCapability(_RangeCapability):
     def get_value(self):
         """Return the state value of this capability for this entity."""
         brightness = self.state.attributes.get(light.ATTR_BRIGHTNESS)
-        if brightness is None:
-            return 0
-        else:
+        if brightness is not None:
             return int(100 * (brightness / 255))
 
     async def set_state(self, data, state):
@@ -1398,16 +1396,9 @@ class TemperatureKCapability(_ColorSettingCapability):
 
     def get_value(self):
         """Return the state value of this capability for this entity."""
-
-        return color_util.color_temperature_mired_to_kelvin(
-            self.state.attributes.get(
-                light.ATTR_COLOR_TEMP, 
-                self.state.attributes.get(
-                    light.ATTR_MAX_MIREDS, 
-                    500
-                )
-            )
-        )
+        temperature_mired = self.state.attributes.get(light.ATTR_COLOR_TEMP)
+        if temperature_mired is not None:
+            return color_util.color_temperature_mired_to_kelvin(temperature_mired)
 
     async def set_state(self, data, state):
         """Set device state."""


### PR DESCRIPTION
В текущей реализации для Яркости, Цвета и Температуры возвращаются нулевые значения если соответствующий атрибут у сущности пустой. Типичный пример - выключенный светильник.
Проблема в том, что "0" это совсем не "None" (а Яндекс в None не может как известно), в результате мы отправляем заведомо ложные данные. Ситуация особенно усугубляется например для температуры, для неё сейчас возвращается минимально возможное значение для этой сущности (т.е. возвращаем "теплый свет" когда лампочка выключена, хотя до выключения она могла была "холодной").

Предлагаю вообще не возвращать capability для None значений (поддержка была добавлена в #210). В этом случае Яндекс будет отображать последнее значение по этой capability. Например, при выключении светильника Яндекс будет показывать его последнюю яркость, температуру и цвет.

Подобное поведение "возвращаем что-нибудь, не важно правда или нет" есть и в других capability, но предлагаю начать пока с лампочек :)
