### PR TITLE
Возможность управлять влажностью для увлажнителей Xiaomi

### DIFF
--- a/custom_components/yandex_smart_home/const.py
+++ b/custom_components/yandex_smart_home/const.py
@@ -76,6 +76,12 @@ TYPE_IRON = PREFIX_TYPES + 'iron'
 TYPE_SENSOR = PREFIX_TYPES + 'sensor'
 TYPE_OTHER = PREFIX_TYPES + 'other'
 
+# Integration xiaomi_airpurifier
+ATTR_TARGET_HUMIDITY = 'target_humidity'
+DOMAIN_XIAOMI_AIRPURIFIER = 'xiaomi_miio_airpurifier'
+MODEL_PREFIX_XIAOMI_AIRPURIFIER = 'zhimi.'
+SERVICE_FAN_SET_TARGET_HUMIDITY = 'fan_set_target_humidity'
+
 # Error codes
 # https://yandex.ru/dev/dialogs/alice/doc/smart-home/concepts/response-codes-docpage/
 ERR_DEVICE_UNREACHABLE = "DEVICE_UNREACHABLE"


### PR DESCRIPTION
Увлажнители Xiaomi, подключенные через интеграцию [xiaomi_airpurifier](https://github.com/syssi/xiaomi_airpurifier), находятся в домене `fan`. Поэтому установка влажности штатным сервисом `humidifer.set_humidity` для них не будет работать.

Этот пулл реквест добавляет поддержку установки влажности для таких увлажнителей. 