### PR TITLE
Inverted logic for getting the state of toggle

### DIFF
--- a/custom_components/yandex_smart_home/capability_custom.py
+++ b/custom_components/yandex_smart_home/capability_custom.py
@@ -6,7 +6,7 @@ import itertools
 import logging
 from typing import Any
 
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers.service import async_call_from_config
 
@@ -122,7 +122,7 @@ class CustomToggleCapability(CustomCapability, ToggleCapability):
         if not self.retrievable:
             return None
 
-        return super().get_value() in [STATE_ON, True]
+        return not super().get_value() in [STATE_OFF, False]
 
     async def set_state(self, data: RequestData, state: dict[str, Any]):
         """Set device state."""


### PR DESCRIPTION
В случае с использованием select в качестве переключателя в HA - состояние кастомного тоггла в УДЯ не определяется и всегда `false` 
Данное изменение решает проблему инвертируя логику получения статуса с "`if true`" на "`if not false`"

на скрине пример конфигурации которая неверно работает в текущей версии
![image](https://user-images.githubusercontent.com/8779304/160360520-2d519b50-a1e8-453f-b23d-d8f3d22eec52.png)
