### PR TITLE
Fixed binary battery level sensor

### DIFF
--- a/custom_components/yandex_smart_home/property_event.py
+++ b/custom_components/yandex_smart_home/property_event.py
@@ -242,7 +242,6 @@ class BatteryLevelEventProperty(EventProperty[BatteryLevelInstanceEvent], Protoc
     _event_map_default: EventMapT[BatteryLevelInstanceEvent] = {
         BatteryLevelInstanceEvent.LOW: _BOOLEAN_TRUE + ["low"],
         BatteryLevelInstanceEvent.NORMAL: _BOOLEAN_FALSE + ["normal"],
-        BatteryLevelInstanceEvent.HIGH: ["high"],
     }
 
     @property

--- a/custom_components/yandex_smart_home/schema/property_event.py
+++ b/custom_components/yandex_smart_home/schema/property_event.py
@@ -86,7 +86,6 @@ class BatteryLevelInstanceEvent(EventInstanceEvent):
 
     LOW = "low"
     NORMAL = "normal"
-    HIGH = "high"
 
 
 class FoodLevelInstanceEvent(EventInstanceEvent):

--- a/tests/test_property_event.py
+++ b/tests/test_property_event.py
@@ -199,7 +199,7 @@ async def test_state_property_event_battery(
 
     assert prop.retrievable is True
     assert prop.parameters == {
-        "events": [{"value": "low"}, {"value": "normal"}, {"value": "high"}],
+        "events": [{"value": "low"}, {"value": "normal"}],
         "instance": "battery_level",
     }
     assert prop.get_value() == "low"


### PR DESCRIPTION
Исправлена работа бинарных датчиков уровня заряда батареи [в соответствии с API](https://yandex.ru/dev/dialogs/smart-home/doc/ru/concepts/event-instance#battery_level).