### PR TITLE
Добавление новыйх типов штор, как штор умные дома яндекс и маруся

### DIFF
--- a/custom_components/yandex_smart_home/device.py
+++ b/custom_components/yandex_smart_home/device.py
@@ -143,6 +143,8 @@ _DEVICE_CLASS_TO_DEVICE_TYPES: dict[tuple[str, str], DeviceType] = {
     (binary_sensor.DOMAIN, BinarySensorDeviceClass.VIBRATION): DeviceType.SENSOR_VIBRATION,
     (binary_sensor.DOMAIN, BinarySensorDeviceClass.WINDOW): DeviceType.SENSOR_OPEN,
     (cover.DOMAIN, CoverDeviceClass.CURTAIN): DeviceType.OPENABLE_CURTAIN,
+    (cover.DOMAIN, CoverDeviceClass.BLIND): DeviceType.OPENABLE_CURTAIN,
+    (cover.DOMAIN, CoverDeviceClass.SHUTTER): DeviceType.OPENABLE_CURTAIN,
     (media_player.DOMAIN, MediaPlayerDeviceClass.RECEIVER): DeviceType.MEDIA_DEVICE_RECIEVER,
     (media_player.DOMAIN, MediaPlayerDeviceClass.TV): DeviceType.MEDIA_DEVICE_TV,
     (sensor.DOMAIN, EventDeviceClass.BUTTON): DeviceType.SENSOR_BUTTON,


### PR DESCRIPTION
Следующие типы доабвлены

1. Жалюзи
2. Рольставни

В версии 0.6 по видимому весь домен `cover` представлялся как штора, после обновления до версии 1.0.2 в нашем случае Маруся перестала видень рулонные шторы, как шторы

В текущих версиях workarounв это проставление device_class: `curtain`, однако в этом случае для рулонных штор меняется иконка на шторы в homeassistant, что выглядит нелепо

Соответвенно данный небольшой патч расширяет набор различных типов штор