### PR TITLE
Добавление типа устройства "Автомобиль"

### DIFF
--- a/custom_components/yandex_smart_home/schema/device.py
+++ b/custom_components/yandex_smart_home/schema/device.py
@@ -53,6 +53,7 @@ class DeviceType(StrEnum):
     KETTLE = "devices.types.cooking.kettle"
     MULTICOOKER = "devices.types.cooking.multicooker"
     REFRIGERATOR = "devices.types.refrigerator"
+    REMOTE_CAR = "devices.types.remote_car"
     OPENABLE = "devices.types.openable"
     OPENABLE_BARRIER = "devices.types.openable.barrier"
     OPENABLE_CURTAIN = "devices.types.openable.curtain"


### PR DESCRIPTION
## Описание
Это PR добавляет типа устройства "Автомобиль".

Что позволяет передать switch объект удаленного запуска автомобиля в УДЯ в виде устройства "Автомобиль".

1. Это дает интуитивно понятную карточку "Автомобиль", а также интуитивно понятные голосовые команды для удаленного запуска.
2. Это повышает безопасность для тех, кто сейчас использует для этих целей тип устройства "Выключатель".

> Управлять автомобилем может только администратор, у гостей умного дома нет доступа к автомобилю. Для голосового управления необходимо познакомиться с колонкой.
> При добавлении устройства в УДЯ можно задать дополнительную кодовую фразу (не обязательно, поле можно оставить пустым). В этом случае для выполнения команды скажите Станции команду, затем одно из слов: «пароль», «пин», «код» или «пин-код» и назовите кодовую фразу. Например: «Алиса, заведи двигатель, код: зима».

<img width="236" height="512" alt="IMG_0921" src="https://github.com/user-attachments/assets/db1cc5e5-276a-498a-b8df-c0209367a4f0" />


## Пример
```yaml
yandex_smart_home:
  entity_config:
    switch.pandora_car_engine:
      type: devices.types.remote_car
```