### PR TITLE
Harden _get_entry_alias against non-string entries (#665)

### DIFF
--- a/custom_components/yandex_smart_home/device.py
+++ b/custom_components/yandex_smart_home/device.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 import logging
 import re
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import (
@@ -459,7 +459,7 @@ class Device:
             return str(room)
 
         if area:
-            if alias := self._get_entry_alias(area.aliases):
+            if alias := self._get_entry_alias(area.aliases or ()):
                 return alias
 
             return area.name

--- a/custom_components/yandex_smart_home/device.py
+++ b/custom_components/yandex_smart_home/device.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import (
@@ -447,10 +448,8 @@ class Device:
         if name := self._config.get(CONF_NAME):
             return str(name)
 
-        if entity_entry:
-            aliases: set[str] = {alias for alias in (entity_entry.aliases or ()) if isinstance(alias, str)}
-            if alias := self._get_entry_alias(aliases):
-                return alias
+        if entity_entry and (alias := self._get_entry_alias(entity_entry.aliases or ())):
+            return alias
 
         return self._state.name or self.id
 
@@ -467,10 +466,20 @@ class Device:
 
         return None
 
-    def _get_entry_alias(self, aliases: set[str]) -> str | None:
-        """Return best matched entry alias."""
+    def _get_entry_alias(self, aliases: Iterable[Any]) -> str | None:
+        """Return best matched entry alias.
+
+        Starting with Home Assistant 2026.4, ``RegistryEntry.aliases`` is typed as
+        ``list[str | ComputedNameType]``, where ``ComputedNameType`` is a sentinel
+        enum value indicating that the full computed entity name should be used
+        in place of a literal alias (see #665). Filtering by ``isinstance(..., str)``
+        here protects every caller (entity/area aliases and any future source)
+        from ``AttributeError: 'ComputedNameType' object has no attribute 'lower'``.
+        """
         filtered_aliases: set[str] = set()
         for alias in aliases:
+            if not isinstance(alias, str):
+                continue
             if "алиса:" in alias.lower():
                 filtered_aliases.add(alias.split(":", 1)[1].strip())
             elif self._entry_data.use_entry_aliases and re.search(r"^[а-яё0-9 ]+$", alias, flags=re.IGNORECASE):  # noqa: RUF001

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -550,6 +550,52 @@ async def test_device_name_room_ignore_aliases(
     assert d.room == "Комната"
 
 
+@pytest.mark.skipif(
+    not hasattr(er, "COMPUTED_NAME"),
+    reason="COMPUTED_NAME sentinel was introduced in Home Assistant 2026.4",
+)
+async def test_device_name_room_ignores_non_string_aliases(
+    hass: HomeAssistant,
+    entry_data: MockConfigEntryData,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    area_registry: ar.AreaRegistry,
+) -> None:
+    """Regression test for #665.
+
+    Starting with Home Assistant 2026.4, ``RegistryEntry.aliases`` is typed as
+    ``list[str | ComputedNameType]``. ``describe()`` used to call ``.lower()``
+    on every alias unconditionally, raising ``AttributeError`` the moment the
+    sentinel showed up in the list. The fix must silently skip non-string
+    entries and still pick the best string alias from whatever remains.
+    """
+    area_closet = area_registry.async_create("Closet", aliases={"Кладовка"})
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+
+    state = State("switch.test_1", STATE_ON)
+    dev_entry = device_registry.async_get_or_create(
+        identifiers={("test_1", "test_1")}, config_entry_id=config_entry.entry_id
+    )
+    entry = entity_registry.async_get_or_create("switch", "test", "1", device_id=dev_entry.id)
+    entity_registry.async_update_entity(
+        entry.entity_id,
+        area_id=area_closet.id,
+        aliases=[er.COMPUTED_NAME, "Алиса: Тостер"],
+    )
+
+    device = Device(hass, entry_data, state.entity_id, state)
+    d = await device.describe()
+    assert d
+    assert d.name == "Тостер"
+    assert d.room == "Кладовка"
+
+    entity_registry.async_update_entity(entry.entity_id, aliases=[er.COMPUTED_NAME])
+    d = await device.describe()
+    assert d
+    assert d.name == "test 1"
+
+
 async def test_device_should_expose(hass: HomeAssistant, entry_data: MockConfigEntryData) -> None:
     entry_data = MockConfigEntryData(hass, entity_filter=generate_entity_filter(exclude_entities=["switch.not_expose"]))
     device = Device(hass, entry_data, "switch.test", State("switch.test", STATE_ON))


### PR DESCRIPTION
## Контекст

Фикс в 2300a14 закрыл #665 через фильтр `isinstance(alias, str)` внутри `_get_name` — но симметричный путь через `_get_room` → `area.aliases` остался без защиты, и внутри `_get_entry_alias` всё так же идёт безусловный `.lower()`. Если HA когда-нибудь начнёт прокидывать `ComputedNameType` через `AreaEntry.aliases` (а в `RegistryEntry.aliases` оно уже живёт), `describe()` упадёт ровно той же ошибкой на соседней ветке кода.

Плюс регрессионного теста на #665 в репозитории нет, так что если кто-то случайно откатит фильтр, CI этого не поймает.

## Что сделано

1. Фильтр `isinstance(alias, str)` переехал **внутрь `_get_entry_alias`**, а сигнатура расширена до `Iterable[Any]`. Теперь защищены все существующие и будущие callers (и `entity_entry.aliases`, и `area.aliases`), код остался однострочным.
2. Добавил docstring с отсылкой на #665 и объяснением зачем нужен guard — чтобы будущий мейнтейнер не подумал что это лишний код и не снёс его.
3. Упростил `_get_name`: set-comprehension больше не нужен, всё в `_get_entry_alias`.
4. Добавил регрессионный тест `test_device_name_room_ignores_non_string_aliases`, который воспроизводит исходный traceback из #665 через `entity_registry.async_update_entity(aliases=[er.COMPUTED_NAME, "Алиса: Тостер"])` и проверяет:
   - `describe()` не падает,
   - строковый алиас корректно выбирается (`name == "Тостер"`),
   - чистый sentinel-only случай падает обратно в `state.name`.

Тест помечен `@pytest.mark.skipif(not hasattr(er, "COMPUTED_NAME"), ...)` — на HA < 2026.4 он пропускается, так как sentinel там просто не существует.

## Проверки

- `ruff check`, `ruff format --check`, `mypy` — зелёные на изменённых файлах.
- `tox -e 2026_4` — полный прогон, **801 passed** под HA 2026.4.0b4.
- Negative control: временно убрал guard внутри `_get_entry_alias` — тест упал с тем самым `AttributeError: 'ComputedNameType' object has no attribute 'lower'` (traceback один-в-один как в #665). Guard вернул — тест снова зелёный. То есть тест реально ловит регрессию, а не зелёный случайно.